### PR TITLE
Move ansible cofiguration group to webservers

### DIFF
--- a/src/example_04/ansible_ping.py
+++ b/src/example_04/ansible_ping.py
@@ -49,7 +49,7 @@ def configure():
     entry = "{machine_address} {pkf}={pem_file_path}\n".format(**args)
 
     with open(ANSIBLE_HOSTS_FILE, 'w') as ansible_hosts_file:
-        ansible_hosts_file.write("[example]\n")
+        ansible_hosts_file.write("[webservers]\n")
         ansible_hosts_file.write(entry)
 
     print "\n"
@@ -66,7 +66,7 @@ def example_04():
     """Configure `ansible_hosts` and run ansible ping command"""
 
     os.environ['ANSIBLE_HOSTS'] = ANSIBLE_HOSTS_FILE
-    cmd = "ansible example -m ping -u ec2-user"
+    cmd = "ansible webservers -m ping -u ec2-user"
     subprocess.call(cmd, shell=True)
 
 if __name__ == '__main__':

--- a/src/example_04/output.txt
+++ b/src/example_04/output.txt
@@ -1,19 +1,18 @@
-prompt> ./ansible_ping.py 
+prompt> python ansible_ping.py
 Configuring `ansible_hosts` file...
 
 
 What is the path to your Amazon pem key?
---> ./my_example_key.pem 
+--> ./my_example_key.pem
 
 
 What is the IP address of the Amazon Linux free tier machine?
---> demo_04.glenjarvis.com        
-
+--> demos.glenjarvis.com
 
 The authenticity of host 'demo_04.glenjarvis.com (demo_04.glenjarvis.com)' can't be established.
 RSA key fingerprint is 6e:b4:07:0d:d8:c5:6b:29:09:a0:de:50:8c:1c:17:bf.
 Are you sure you want to continue connecting (yes/no)? yes
-demo_04.glenjarvis.com | success >> {
+demos.glenjarvis.com | success >> {
     "changed": false, 
     "ping": "pong"
 }


### PR DESCRIPTION
We we later look at this, we'll be building a webserver. So, this is
less change later. Also, it can be less confusing if we use something
meaningful (like a webserver group) instead of just the group 'example'
