### PR TITLE
Move `ansible_hosts` to example_06

### DIFF
--- a/src/example_04/ansible_ping.py
+++ b/src/example_04/ansible_ping.py
@@ -27,7 +27,7 @@ import subprocess
 
 ANSIBLE_HOSTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
-    'ansible_hosts')
+    '../example_06/ansible_hosts')
 
 
 def configure():

--- a/src/example_04/output.txt
+++ b/src/example_04/output.txt
@@ -9,8 +9,8 @@ What is the path to your Amazon pem key?
 What is the IP address of the Amazon Linux free tier machine?
 --> demos.glenjarvis.com
 
-The authenticity of host 'demo_04.glenjarvis.com (demo_04.glenjarvis.com)' can't be established.
-RSA key fingerprint is 6e:b4:07:0d:d8:c5:6b:29:09:a0:de:50:8c:1c:17:bf.
+The authenticity of host 'demos.glenjarvis.com (54.213.37.199)' can't be established.
+RSA key fingerprint is ef:59:04:b1:f0:74:e4:0b:ef:92:ee:0a:ef:be:8b:dc.
 Are you sure you want to continue connecting (yes/no)? yes
 demos.glenjarvis.com | success >> {
     "changed": false, 

--- a/src/example_05/ansible_commands.py
+++ b/src/example_05/ansible_commands.py
@@ -14,39 +14,16 @@ import subprocess
 
 ANSIBLE_HOSTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
-    'ansible_hosts')
+    '../example_06/ansible_hosts')  # This is not a mistake (we will use in 6)
 
 
-def configure():
-    """An example to show how one executes remote commands via ssh"""
-
-    args = {}
-
-    print "Configuring `ansible_hosts` file...\n\n"
-    print "What is the path to your Amazon pem key?"
-    args['pem_file_path'] = raw_input('--> ')
-
-    if not os.path.exists(args['pem_file_path']):
-        print "Nope. This file cannot be found: {pem_file_path}".format(**args)
-        sys.exit(1)
-
-    print "\n\nWhat is the IP address of the Amazon Linux free tier machine?"
-    args['machine_address'] = raw_input('--> ')
-    args['pkf'] = "ansible_ssh_private_key_file"
-    entry = "{machine_address} {pkf}={pem_file_path}\n".format(**args)
-
-    with open(ANSIBLE_HOSTS_FILE, 'w') as ansible_hosts_file:
-        ansible_hosts_file.write("[example]\n")
-        ansible_hosts_file.write(entry)
-
-    print "\n"
-
-
-def check_and_configure():
-    """Check if `ansible_hosts` file exists; Configure if it doesn't"""
+def check_ansible_hosts():
+    """Check if `ansible_hosts` file exists"""
 
     if not os.path.exists(ANSIBLE_HOSTS_FILE):
-        configure()
+        print "We are trying to use the `ansible_hosts` file from"
+        print "example 6. But, we can't find it. Doh!"
+        sys.exit(1)
 
 
 def example_05():
@@ -54,9 +31,9 @@ def example_05():
 
     print "Executing ansible command"
     os.environ['ANSIBLE_HOSTS'] = ANSIBLE_HOSTS_FILE
-    cmd = "ansible example -u ec2-user -a 'sudo yum update -y'"
+    cmd = "ansible webservers -u ec2-user -a 'sudo yum update -y'"
     subprocess.call(cmd, shell=True)
 
 if __name__ == '__main__':
-    check_and_configure()
+    check_ansible_hosts()
     example_05()

--- a/src/example_05/output.txt
+++ b/src/example_05/output.txt
@@ -1,22 +1,8 @@
 # NOTE: You don't get the output until the command is finished.
 
 prompt> python ansible_commands.py 
-Configuring `ansible_hosts` file...
-
-
-What is the path to your Amazon pem key?
---> ./my_example_key.pem
-
-
-What is the IP address of the Amazon Linux free tier machine?
---> 54.186.74.232
-
-
 Executing ansible command
-The authenticity of host '54.186.74.232 (54.186.74.232)' can't be established.
-RSA key fingerprint is 9a:54:58:d6:da:3b:f8:eb:07:d4:0a:c8:4e:33:e9:8a.
-Are you sure you want to continue connecting (yes/no)? yes
-54.186.74.232 | success | rc=0 >>
+demos.glenjarvis.com | success | rc=0 >>
 Loaded plugins: priorities, update-motd, upgrade-helper
 Resolving Dependencies
 --> Running transaction check
@@ -136,7 +122,7 @@ Upgrade  32 Packages
 Total download size: 88 M
 Downloading packages:
 --------------------------------------------------------------------------------
-Total                                               12 MB/s |  88 MB  00:07     
+Total                                              8.1 MB/s |  88 MB  00:10
 Running transaction check
 Running transaction test
 Transaction test succeeded
@@ -310,5 +296,4 @@ Updated:
   readline.x86_64 0:6.2-9.14.amzn1                                              
 
 Complete!
-
 


### PR DESCRIPTION
After reviewing examples 04, 05, and 06, I am moving the creation of the
ansible_hosts file to `example_06`. Initially, we asked the user for the
details and recreated the file each time. However, not only was that
tedious for the user, it also took focus away from the purpose of
ansible.

Example 06 is where the file will be used without a helper script to run
the commands for you (e.g., where the training wheels come off). It is
here that it makes the most sense to put the file (of the three
examples).

It was very tempting to place the file in a default location like
/etc/ansible/hosts or $HOME. However, I hestiate storying anything
outside of this repository (so all data can be cleanly removed if the
user wishes). The user can move this file to a default location if
she/he wishes.
