### PR TITLE
Update configuration for entire repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,41 @@ Instance](http://aws.amazon.com/), I highly recommend [watching this
 video](https://www.youtube.com/watch?v=xZb3cr1JrMg) in advance of the talk.
 
 
+## Getting Started (Installing and following-along)
+
+1. Clone this repo.
+```bash
+prompt> git clone https://github.com/glenjarvis/ansible_tutorial.git
+Cloning into 'ansible_tutorial'...
+remote: Reusing existing pack: 112, done.
+remote: Total 112 (delta 0), reused 0 (delta 0)
+Receiving objects: 100% (112/112), 37.58 KiB | 0 bytes/s, done.
+Resolving deltas: 100% (48/48), done.
+Checking connectivity... done.
+```
+2. Change to the src directory.
+```bash
+prompt> cd ansible_tutorial/src/
+```
+3. Configure the repo for your account and settings
+```bash
+prompt> python configure.py 
+
+    No configuration file found. Let me ask questions so that we can configure.
+    
+What is the path to your Amazon pem key?
+--> example_key.pem
+
+Configuring `ansible_hosts` file ./ansible_hosts...
+
+What is the IP address of the Amazon Linux free tier machine?
+--> demo.example.com
+
+Configuration is complete.
+```
+4. Follow the examples (starting with the `example_01` subdirectory).
+
+
 ## Bio
 Glen has been a full-time Python programmer since 2007 and has worked for
 companies such as IBM, UC Berkeley, Sprint, Informix, and many small start-ups.
@@ -70,3 +105,63 @@ the [Bay Area Python Interest Group](http://baypiggies.net/) organization.
 [Google+](https://plus.google.com/u/0/+GlenJarvis/posts)
 
 [LinkedIn](http://www.linkedin.com/in/glenjarvis)
+
+
+
+### Documentation for configure.py (if needed)
+
+Although this probably won't be needed, here is the coonfigure.py documentation
+that is used to help you configure your ansible.cfg and ansible_hosts files.
+
+
+```python
+Help on module configure:
+
+NAME
+    configure - Configure the demo repository to make it easier to learn/follow
+
+FILE
+    ...ansible-tutorial/src/configure.py
+
+DESCRIPTION
+    This takes the machine name and the AWS pem key path and configures the
+    ansible.cfg and ansible_hosts files. We also avoid the most common
+    gotcha (permissions on the downloaded key file) by setting the
+    permissions to be Read/Write for only the owner.
+
+FUNCTIONS
+    check_and_configure()
+        Check/configure `ansible.cfg` and `ansible_hosts`
+    
+    configure_config()
+        Assuming no ansible.cfg exists, ask questions and create a new one
+    
+    configure_hosts(hostfile)
+        Assuming no hostfile file exists, ask questions and create a new one
+    
+    fix_pem_permissons(pem_file_path)
+        Forcefully fix the PEM file permissions
+        
+        The larest problem that new users have when connecting ot their
+        first AWS instance is that the permissions on the *.pem key that
+        they downloaded is too permissive. It really isn't a *private* key
+        if anyone else on the system (group or other) can read the file.
+        
+        We change the permissions to the file given so that only the owner
+        can read or write. There really isn't a reason to allow write
+        permissions for the key, however, these are the default permissions
+        for an ssh key.
+    
+    get_configured_hosts()
+        Read the ansible.cfg file and parse hostfile pathname
+    
+    write_ansible_cfg_file(pem_file_path)
+        Given a validated pem_file_path, write the ansible configuration file
+
+DATA
+    ANSIBLE_CONFIG_FILENAME = './ansible.cfg'
+    ANSIBLE_CONFIG_FILEPATH = '...ansible-tutorial/src/ansible.cfg'
+    ANSIBLE_HOSTS_FILENAME = './ansible_hosts'
+    ANSIBLE_HOSTS_FILEPATH = '...ansible-tutorial/src/ansible_hosts'
+    BASE_FILE = '...ansible-tutorial/src'
+```

--- a/src/configure.py
+++ b/src/configure.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+
+"""Configure the demo repository to make it easier to learn/follow
+
+This takes the machine name and the AWS pem key path and configures the
+ansible.cfg and ansible_hosts files. We also avoid the most common
+gotcha (permissions on the downloaded key file) by setting the
+permissions to be Read/Write for only the owner.
+"""
+
+import ConfigParser
+import os
+import stat
+import sys
+
+BASE_FILE = os.path.dirname(os.path.abspath(__file__))
+ANSIBLE_HOSTS_FILENAME = './ansible_hosts'
+ANSIBLE_HOSTS_FILEPATH = os.path.join(BASE_FILE, ANSIBLE_HOSTS_FILENAME)
+ANSIBLE_CONFIG_FILENAME = './ansible.cfg'
+ANSIBLE_CONFIG_FILEPATH = os.path.join(BASE_FILE, ANSIBLE_CONFIG_FILENAME)
+
+
+def fix_pem_permissons(pem_file_path):
+
+    """Forcefully fix the PEM file permissions
+
+    The larest problem that new users have when connecting ot their
+    first AWS instance is that the permissions on the *.pem key that
+    they downloaded is too permissive. It really isn't a *private* key
+    if anyone else on the system (group or other) can read the file.
+
+    We change the permissions to the file given so that only the owner
+    can read or write. There really isn't a reason to allow write
+    permissions for the key, however, these are the default permissions
+    for an ssh key.
+    """
+    os.chmod(pem_file_path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def write_ansible_cfg_file(pem_file_path):
+
+    """Given a validated pem_file_path, write the ansible configuration file"""
+
+    fix_pem_permissons(pem_file_path)
+    config = ConfigParser.RawConfigParser()
+    config.add_section('defaults')
+    config.set('defaults', 'hostfile', ANSIBLE_HOSTS_FILENAME)
+    config.set('defaults', 'private_key_file', pem_file_path)
+    config.set('defaults', 'remote_user', 'ec2-user')
+
+    with open(ANSIBLE_CONFIG_FILENAME, 'wb') as config_file:
+        config.write(config_file)
+
+
+def configure_config():
+
+    """Assuming no ansible.cfg exists, ask questions and create a new one"""
+
+    print """
+    No configuration file found. Let me ask questions so that we can configure.
+    """
+
+    print "What is the path to your Amazon pem key?"
+    pem_file_path = raw_input('--> ')
+
+    if not os.path.exists(pem_file_path):
+        print "Nope. This file cannot be found: {pem_file_path}".format(
+            pem_file_path=pem_file_path)
+        sys.exit(1)
+
+    write_ansible_cfg_file(pem_file_path)
+    print "\n"
+
+
+def get_configured_hosts():
+
+    """Read the ansible.cfg file and parse hostfile pathname"""
+
+    config = ConfigParser.SafeConfigParser()
+    config.read(ANSIBLE_CONFIG_FILENAME)
+
+    hostfile = config.get('defaults', 'hostfile')
+    if hostfile is None:
+        print "We can't read the hostfile settings from {0}".format(
+            ANSIBLE_CONFIG_FILENAME)
+        sys.exit(2)
+
+    return hostfile
+
+
+def configure_hosts(hostfile):
+
+    """Assuming no hostfile file exists, ask questions and create a new one"""
+
+    print "Configuring `ansible_hosts` file {0}...\n\n".format(hostfile)
+
+    print "\n\nWhat is the IP address of the Amazon Linux free tier machine?"
+    machine_address = raw_input('--> ')
+
+    with open(hostfile, 'w') as ansible_hosts_file:
+        ansible_hosts_file.write("[webservers]\n")
+        ansible_hosts_file.write(machine_address)
+
+
+def check_and_configure():
+    """Check/configure `ansible.cfg` and `ansible_hosts`"""
+
+    if not os.path.exists(ANSIBLE_CONFIG_FILEPATH):
+        configure_config()
+
+    # Re-read the hosts from the config file in case it is changed by
+    # the user
+    hostfile = get_configured_hosts()
+
+    if not os.path.exists(hostfile):
+        configure_hosts(hostfile)
+
+    print "\nConfiguration is complete."
+
+
+if __name__ == '__main__':
+    check_and_configure()

--- a/src/example_04/ansible.cfg
+++ b/src/example_04/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg

--- a/src/example_04/ansible_hosts
+++ b/src/example_04/ansible_hosts
@@ -1,0 +1,1 @@
+../ansible_hosts

--- a/src/example_05/ansible.cfg
+++ b/src/example_05/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg

--- a/src/example_05/ansible_hosts
+++ b/src/example_05/ansible_hosts
@@ -1,0 +1,1 @@
+../ansible_hosts


### PR DESCRIPTION
Previously, I had configured the ansible_hosts for every example. I think this
adds confusion and takes away from the idea of how ansible works. These are now
configured automatically (python configure.py).

We can then read these config files in our examples instead.
