### PR TITLE
Fix symlinks for playbook_examples

### DIFF
--- a/src/playbook_examples/ansible.cfg
+++ b/src/playbook_examples/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg

--- a/src/playbook_examples/ansible_hosts
+++ b/src/playbook_examples/ansible_hosts
@@ -1,0 +1,1 @@
+../ansible_hosts


### PR DESCRIPTION
When checking out a fresh repo (to more ruggedly test the repo), I discovered
that the two symlinks to the ansible.cfg and ansible_hosts were not working.
This means that none of the playbook_examples would have worked unless someone
knew to make these links (I'm trying to make that easy so one doesn't have to
think about such things until the core concepts are covered). Fixing now.
