### PR TITLE
Remove ec2-user from playbooks

### DIFF
--- a/src/playbook_examples/demo_playbook_iter_01.yml
+++ b/src/playbook_examples/demo_playbook_iter_01.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: webservers
-  remote_user: ec2-user
   tasks:
   - name: Make sure all OS patches are applied
     shell: yum update -y

--- a/src/playbook_examples/demo_playbook_iter_02.yml
+++ b/src/playbook_examples/demo_playbook_iter_02.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: webservers
-  remote_user: ec2-user
   tasks:
   - name: Make sure all OS patches are applied
     shell: yum update -y

--- a/src/playbook_examples/demo_playbook_iter_03.yml
+++ b/src/playbook_examples/demo_playbook_iter_03.yml
@@ -1,7 +1,6 @@
 ---
 - include: demo_playbook_iter_01.yml
 - hosts: webservers
-  remote_user: ec2-user
   tasks:
   - name: Install our needed packages for AWS Linux
     shell: yum install -y git

--- a/src/playbook_examples/demo_playbook_iter_04.yml
+++ b/src/playbook_examples/demo_playbook_iter_04.yml
@@ -1,7 +1,6 @@
 ---
 - include: demo_playbook_iter_01.yml
 - hosts: webservers
-  remote_user: ec2-user
   tasks:
   - name: Install our needed packages for AWS Linux
     yum: state=present name=git

--- a/src/playbook_examples/demo_playbook_iter_05.yml
+++ b/src/playbook_examples/demo_playbook_iter_05.yml
@@ -1,7 +1,6 @@
 ---
 - include: demo_playbook_iter_01.yml
 - hosts: webservers
-  remote_user: ec2-user
   vars:
     our_desired_package_name: git
   tasks:

--- a/src/playbook_examples/demo_playbook_iter_07.yml
+++ b/src/playbook_examples/demo_playbook_iter_07.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: webservers
-  remote_user: ec2-user
   vars:
     our_desired_package_name: nginx
   tasks:

--- a/src/playbook_examples/demo_playbook_iter_08.yml
+++ b/src/playbook_examples/demo_playbook_iter_08.yml
@@ -3,7 +3,6 @@
 # Handlers are nothing but tasks that get triggered by
 # a "notify"
 - hosts: webservers
-  remote_user: ec2-user
   vars:
     our_desired_package_name: nginx
   tasks:

--- a/src/playbook_examples/demo_playbook_iter_09.yml
+++ b/src/playbook_examples/demo_playbook_iter_09.yml
@@ -1,7 +1,6 @@
 ---
 - include: demo_playbook_iter_05.yml our_desired_package_name=nginx
 - hosts: webservers
-  remote_user: ec2-user
   vars:
      demo_message: 'Hello World (of course)'
   handlers:

--- a/src/roles_examples/demo_play_role_01.yml
+++ b/src/roles_examples/demo_play_role_01.yml
@@ -1,5 +1,4 @@
 - name: Demonstrate our work in a directory (now called a 'role')
   hosts: webservers
-  remote_user: ec2-user
   roles:
     - python_stack

--- a/src/roles_examples/demo_play_role_02.yml
+++ b/src/roles_examples/demo_play_role_02.yml
@@ -1,5 +1,4 @@
 - name: Demonstrate a working deploy of nginx (using python_webstack)
   hosts: webservers
-  remote_user: ec2-user
   roles:
     - web_server_nginx

--- a/src/roles_examples/demo_play_role_03.yml
+++ b/src/roles_examples/demo_play_role_03.yml
@@ -7,7 +7,6 @@
 
 - name: Demonstrate a Django setup (But Django service NOT started)
   hosts: webservers
-  remote_user: ec2-user
   roles:
     - web_server_nginx
     - app_server_django


### PR DESCRIPTION
Remove:

```
remote_user: ec2-user
```

from a bunch of playbooks, because I'm using OpenStack and don't have that user and it's not necessary anyway, because a default `remote_user` is already set in `src/ansible.cfg`.
