### PR TITLE
Add -vvv explanation to README.txt

### DIFF
--- a/src/example_05/README.txt
+++ b/src/example_05/README.txt
@@ -6,3 +6,14 @@ Here is the command that should ping your webservers. Just run this command
 from this directory:
 
 ansible webservers -a 'sudo yum update -y'
+
+To get more verbose output, use the `-v` (verbose) option, which can be
+specified multiple times.
+
+Try:
+
+    ansible webservers -vv -a 'sudo yum update -y'
+
+or:
+
+    ansible webservers -vvv -a 'sudo yum update -y'


### PR DESCRIPTION
This is a partial "change of mind" from a previous pull request covnersation
with https://github.com/msabramo. In that conversation he suggested adding
the '-vvv' options to the command. I wanted to keep this output short and
easier to digest.

But, I realize that there is a difference between this example and the previous
one. The previous example was using a module '-m' and this example sending a command '-a'.

So, verbose should be explained again to show that verbose can be used in
either scneario. In future commits these two examples order will be switched
(because the command makes more sense to introduce first before the module.)
