### PR TITLE
Use initially declared constant consistently: ANSIBLE_CFG

### DIFF
--- a/src/example_01/access_machine.py
+++ b/src/example_01/access_machine.py
@@ -45,11 +45,11 @@ def get_settings():
         sys.exit(1)
 
     config = ConfigParser.SafeConfigParser()
-    config.read('./ansible.cfg')
+    config.read(ANSIBLE_CFG)
 
     hostfile = config.get('defaults', 'hostfile')
     if hostfile is None:
-        print "We can't read the hostfile from ansible.cfg"
+        print "We can't read the hostfile from {0}".format(ANSIBLE_CFG)
         sys.exit(2)
 
     private_key = config.get('defaults', 'private_key_file')


### PR DESCRIPTION
ANSIBLE_CFG = './ansible.cfg'
Replace remaining references to './ansible.cfg' with ANSIBLE_CFG
